### PR TITLE
gyazo.comにExtensionの有無を通知する

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,5 +1,9 @@
 (function() {
 
+if(/gyazo\.com/.test(location.hostname)){
+  document.documentElement.setAttribute("data-extension-installed", true);
+}
+
 function changeFixedElementToAbsolute(){
   Array.prototype.slice.apply(document.querySelectorAll('*')).filter(function(item){
     return (window.getComputedStyle(item).position === 'fixed')

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Gyazo",
   "description": "Grab any image on the web and share it instantly.",
   "short_name": "Gyazo",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": "Nota inc.",
   "permissions": [
     "<all_urls>",
@@ -15,7 +15,7 @@
   "content_scripts": [{
     "matches": ["<all_urls>"],
     "js": ["content.js"],
-    "run_at": "document_end"
+    "run_at": "document_start"
   }],
   "background": {
     "scripts": ["main.js","libs/jquery-1.10.2.min.js", "libs/utils.js"],


### PR DESCRIPTION
Extensionでは`chrome.app.isInstalled`が常に`false`になる（Chrome Apps向けにのみ提供されているAPIっぽい）ので、gyazo.comにDOMを経由して値を渡す。