### PR TITLE
fix inserting gray line on Windows ( fix #21 #17)

### DIFF
--- a/content.js
+++ b/content.js
@@ -116,6 +116,13 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
       changeFixedElementToAbsolute();
       window.scroll(0, 0);
       var zoom = Math.round(window.outerWidth / window.innerWidth * 100) / 100;
+	  var windowInnerHeight = window.innerHeight;
+	  // XXX: on Windows, when window is not maximum, it should tweak zoom.(Chrome zoom level 1 is 1.10)
+	  var isWindows = navigator.platform.match(/^win/i);
+	  var isMaximum = (window.outerHeight === screen.availHeight);
+	  if( isWindows && !isMaximum && 1.00 < zoom && zoom < 1.05){
+	  	zoom = 1.00;
+	  };
       var data = {
         width: window.outerWidth,
         height: Math.max(document.body.clientHeight, document.body.offsetHeight, document.body.scrollHeight),

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Gyazo",
   "description": "Grab any image on the web and share it instantly.",
   "short_name": "Gyazo",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "author": "Nota inc.",
   "permissions": [
     "<all_urls>",


### PR DESCRIPTION
# Reason 

 It calculates `window.outerWidth / window.innerWidth`  to get browser zoom setting. chrome is not maxium, `window.outerWidth` contains window's border. So, calculated value is bigger than actual zoom setting.

# Solution 

Default size of Windows border width is 8px. So  `window.outerWidth / window.innerWidth` get bigger 1%. And Google Chrome zoom level 1 is 110%.

Maybe, on Windows, not Maximum and  zoom rate < 105, round rate to 100.