### PR TITLE
Strict of isMaximum. fix #17

### DIFF
--- a/content.js
+++ b/content.js
@@ -119,7 +119,7 @@ chrome.runtime.onMessage.addListener(function(request, sender, sendResponse){
 	  var windowInnerHeight = window.innerHeight;
 	  // XXX: on Windows, when window is not maximum, it should tweak zoom.(Chrome zoom level 1 is 1.10)
 	  var isWindows = navigator.platform.match(/^win/i);
-	  var isMaximum = (window.outerHeight === screen.availHeight);
+	  var isMaximum = (window.outerHeight === screen.availHeight && window.outerWidth === screen.availWidth);
 	  if( isWindows && !isMaximum && 1.00 < zoom && zoom < 1.05){
 	  	zoom = 1.00;
 	  };


### PR DESCRIPTION
縦幅が最大 + 横幅が任意のサイズ の時にバグが再発するので修正。
http://kaelab.ranadesign.com/blog/2010/10/javascript-5.html