### PR TITLE
Remove unnecessary text at gyazo element. 

### DIFF
--- a/content.js
+++ b/content.js
@@ -339,13 +339,16 @@
 
           // Sanitize gyazo desc for ivy-search
           var dup_target = event.target.cloneNode(true)
-          Array.from(dup_target.querySelectorAll('*')).forEach((elm) => {
-            if (elm.tagName === 'SCRIPT' || elm.tagName === 'STYLE') {
-                elm.remove()
-                continue;
-            }
+          Array.from(dup_target.querySelectorAll('*')).forEach(function (elm) {
             if (getComputedStyle(elm).display === 'none' || getComputedStyle(elm).visibility === 'hidden') {
-                elm.remove()
+                return elm.remove()
+            }
+          })
+          Array.from(dup_target.querySelectorAll('*')).forEach(function (elm) {
+            switch (elm.tagName) {
+              case 'SCRIPT':
+              case 'STYLE':
+                return elm.remove()
             }
           })
 

--- a/content.js
+++ b/content.js
@@ -347,7 +347,7 @@
           data.positionX = window.scrollX
           data.positionY = window.scrollY
           data.innerHeight = window.innerHeight
-          data.desc = event.target.textContent
+          data.desc = event.target.innerHTML
           if (document.body.contains(layer)) {
             document.body.removeChild(layer)
           }

--- a/content.js
+++ b/content.js
@@ -339,7 +339,7 @@
 
           // Sanitize gyazo desc for ivy-search
           Array.from(window.document.querySelectorAll('*')).forEach(function (elm) {
-            if (getComputedStyle(elm).display === 'none' || getComputedStyle(elm).visibility === 'hidden') {
+            if (window.getComputedStyle(elm).display === 'none' || window.getComputedStyle(elm).visibility === 'hidden') {
               elm.classList.add('gyazo-hidden')
             }
           })

--- a/content.js
+++ b/content.js
@@ -339,10 +339,15 @@
 
           // Sanitize gyazo desc for ivy-search
           var dup_target = event.target.cloneNode(true)
-          var desc_scripts = dup_target.getElementsByTagName('script')
-          Array.from(desc_scripts).forEach(function (script) { script.parentNode.removeChild(script) })
-          var desc_css = dup_target.getElementsByTagName('style')
-          Array.from(desc_css).forEach(function (css) { css.parentNode.removeChild(css) })
+          Array.from(dup_target.querySelectorAll('*')).forEach((elm) => {
+            if (elm.tagName === 'SCRIPT' || elm.tagName === 'STYLE') {
+                elm.remove()
+                continue;
+            }
+            if (getComputedStyle(elm).display === 'none' || getComputedStyle(elm).visibility === 'hidden') {
+                elm.remove()
+            }
+          })
 
           data.w = parseFloat(layer.style.width)
           data.h = parseFloat(layer.style.height)

--- a/content.js
+++ b/content.js
@@ -336,6 +336,14 @@
           })
           var data = {}
           var scaleObj = getZoomAndScale()
+
+          // Sanitize gyazo desc for ivy-search
+          var dup_target = event.target.cloneNode(true)
+          var desc_scripts = dup_target.getElementsByTagName('script')
+          Array.from(desc_scripts).forEach(function(script){ script.parentNode.removeChild(script) })
+          var desc_css = dup_target.getElementsByTagName('style')
+          Array.from(desc_css).forEach(function(css){ css.parentNode.removeChild(css) })
+
           data.w = parseFloat(layer.style.width)
           data.h = parseFloat(layer.style.height)
           data.x = window.scrollX + layer.offsetLeft
@@ -347,7 +355,7 @@
           data.positionX = window.scrollX
           data.positionY = window.scrollY
           data.innerHeight = window.innerHeight
-          data.desc = event.target.innerHTML
+          data.desc = dup_target.textContent
           if (document.body.contains(layer)) {
             document.body.removeChild(layer)
           }

--- a/content.js
+++ b/content.js
@@ -338,18 +338,24 @@
           var scaleObj = getZoomAndScale()
 
           // Sanitize gyazo desc for ivy-search
-          var dup_target = event.target.cloneNode(true)
-          Array.from(dup_target.querySelectorAll('*')).forEach(function (elm) {
+          Array.from(window.document.querySelectorAll('*')).forEach(function (elm) {
             if (getComputedStyle(elm).display === 'none' || getComputedStyle(elm).visibility === 'hidden') {
-                return elm.remove()
+              elm.classList.add('gyazo-hidden')
             }
           })
+          var dup_target = event.target.cloneNode(true)
           Array.from(dup_target.querySelectorAll('*')).forEach(function (elm) {
             switch (elm.tagName) {
               case 'SCRIPT':
               case 'STYLE':
                 return elm.remove()
             }
+            if (elm.classList.contains('gyazo-hidden')) {
+              elm.remove()
+            }
+          })
+          Array.from(window.document.getElementsByClassName('gyazo-hidden')).forEach(function (elm) {
+            elm.classList.remove('gyazo-hidden')
           })
 
           data.w = parseFloat(layer.style.width)

--- a/content.js
+++ b/content.js
@@ -340,9 +340,9 @@
           // Sanitize gyazo desc for ivy-search
           var dup_target = event.target.cloneNode(true)
           var desc_scripts = dup_target.getElementsByTagName('script')
-          Array.from(desc_scripts).forEach(function(script){ script.parentNode.removeChild(script) })
+          Array.from(desc_scripts).forEach(function (script) { script.parentNode.removeChild(script) })
           var desc_css = dup_target.getElementsByTagName('style')
-          Array.from(desc_css).forEach(function(css){ css.parentNode.removeChild(css) })
+          Array.from(desc_css).forEach(function (css) { css.parentNode.removeChild(css) })
 
           data.w = parseFloat(layer.style.width)
           data.h = parseFloat(layer.style.height)

--- a/content.js
+++ b/content.js
@@ -338,13 +338,13 @@
           var scaleObj = getZoomAndScale()
 
           // Sanitize gyazo desc for ivy-search
-          Array.from(window.document.querySelectorAll('*')).forEach(function (elm) {
+          Array.from(document.querySelectorAll('*')).forEach(function (elm) {
             if (window.getComputedStyle(elm).display === 'none' || window.getComputedStyle(elm).visibility === 'hidden') {
               elm.classList.add('gyazo-hidden')
             }
           })
-          var dup_target = event.target.cloneNode(true)
-          Array.from(dup_target.querySelectorAll('*')).forEach(function (elm) {
+          var dupTarget = event.target.cloneNode(true)
+          Array.from(dupTarget.querySelectorAll('*')).forEach(function (elm) {
             switch (elm.tagName) {
               case 'SCRIPT':
               case 'STYLE':
@@ -354,7 +354,7 @@
               elm.remove()
             }
           })
-          Array.from(window.document.getElementsByClassName('gyazo-hidden')).forEach(function (elm) {
+          Array.from(document.getElementsByClassName('gyazo-hidden')).forEach(function (elm) {
             elm.classList.remove('gyazo-hidden')
           })
 
@@ -369,7 +369,7 @@
           data.positionX = window.scrollX
           data.positionY = window.scrollY
           data.innerHeight = window.innerHeight
-          data.desc = dup_target.textContent
+          data.desc = dupTarget.textContent
           if (document.body.contains(layer)) {
             document.body.removeChild(layer)
           }


### PR DESCRIPTION
fix #105 

it is  success to remove textContent from script and style tag.

But it's not enough at google's result page...

[![https://nota.gyazo.com/2c75022a96c0152bc298843a468b50ab](https://t.gyazo.com/teams/nota/2c75022a96c0152bc298843a468b50ab.png)](https://nota.gyazo.com/2c75022a96c0152bc298843a468b50ab)

It seems difficult to remove meaningless words from captured HTML textContent.