### PR TITLE
prevent build on forked PR

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,13 +3,15 @@ machine:
     version: 4.1.0
 dependencies:
   pre:
-    - npm install standard
     - npm install -g chrome-webstore-manager
 test:
   post:
-    - echo $GCS_KEY | base64 --decode > gcs_key.json
-    - gcloud auth activate-service-account --key-file gcs_key.json
-    - ./script/branch2crx
+    - |
+      if [ -z "$CIRCLE_PR_NUMBER" ]; then
+        echo $GCS_KEY | base64 --decode > gcs_key.json
+        gcloud auth activate-service-account --key-file gcs_key.json
+        ./script/branch2crx
+      fi
 deployment:
   production:
     branch: production


### PR DESCRIPTION
It fails to build on PR from users who is not contained owners.

Build on forked PR is not secure ( our repository's build uses secret GCP API Keys ).

So it won't build on forked PR :disappointed: 