### PR TITLE
Fix issue that gyazo it doesn't work

### DIFF
--- a/src/normal/index.js
+++ b/src/normal/index.js
@@ -61,7 +61,7 @@ function onClickHandler (info, tab) {
         url: tab.url
       })
     } else {
-      var xhr = jQuery.ajaxSettings.xhr()
+      var xhr = $.ajaxSettings.xhr()
       xhr.open('GET', info.srcUrl, true)
       xhr.responseType = 'blob'
       xhr.onreadystatechange = function () {


### PR DESCRIPTION
gyazo it button doesn't work because of this error:

```
Reference Error: jQuery is not defined
```

This PR fixes this by using `$` instead of `jQuery`