### PR TITLE
Avoid double loading expander.js

### DIFF
--- a/src/common/content/content.js
+++ b/src/common/content/content.js
@@ -609,6 +609,6 @@
     }
     return true
   })
-})()
 
-require('./expander')
+  require('./expander')
+})()


### PR DESCRIPTION
This change fixes an issue that expander.js is double-loaded at pushState enabled sites such as Github.